### PR TITLE
Fixing 2017 and 2018 configurations

### DIFF
--- a/tauembedding_tagandprobe.py
+++ b/tauembedding_tagandprobe.py
@@ -467,6 +467,8 @@ def build_config(
             ),
             "singlemuon_trigger_bit": EraModifier(
                 {
+                    "2018": [],
+                    "2017": [],
                     "2016preVFP": [
                         {
                             "flagname_1": "trg_Mu17TrkMu8_DZ_bit_12_Mu17_1",


### PR DESCRIPTION
Fixing 2017 and 2018 configurations by adding empty lists to trigger bit config that was introduced in 2016 but are not used in 2017/2018