### PR TITLE
changed WP vsEle for vsJet ID SF for et and mt

### DIFF
--- a/config.py
+++ b/config.py
@@ -363,6 +363,18 @@ def build_config(
             "tau_vsjet_vseleWP": "VVLoose",
         },
     )
+    configuration.add_config_parameters(
+        ["et"],
+        {
+            "tau_vsjet_vseleWP": "Tight",
+        },
+    )
+    configuration.add_config_parameters(
+        ["mt"],
+        {
+            "tau_vsjet_vseleWP": "VVLoose",
+        },
+    )
     # TT tau id sf variations
     configuration.add_config_parameters(
         ["tt"],


### PR DESCRIPTION
the tauID SFs vsJet are measured for VVLoose and Tight vsEle WPs. 
To be consistent with the smhtt_ul framework, the vsEle WPs are VVLoose vsEle in mt and Tight vsEle in et 