### PR TITLE
Fix calculation of number of jets

### DIFF
--- a/producers/jets.py
+++ b/producers/jets.py
@@ -1,5 +1,5 @@
 from ..quantities import output as q
-from ..quantities import nanoAOD as nanoAOD 
+from ..quantities import nanoAOD as nanoAOD
 from ..scripts.CROWNWrapper import Producer, ProducerGroup, defaults
 
 ####################
@@ -139,7 +139,7 @@ with defaults(scopes=["mt", "et", "tt", "em", "mm", "ee"]):
         output=[q.jet_p4_2],
     )
     NumberOfJets = Producer(
-        call="physicsobject::Count({df}, {output}, {input})",
+        call="physicsobject::Size<Int_t>({df}, {output}, {input})",
         input=[q.good_jet_collection],
         output=[q.njets],
     )
@@ -181,7 +181,7 @@ with defaults(scopes=["mt", "et", "tt", "em", "mm", "ee"]):
         LVBJet2 = Producer(call="lorentzvector::Build({df}, {output}, {input}, 1)", output=[q.bjet_p4_2])
 
     NumberOfBJets = Producer(
-        call="physicsobject::Count({df}, {output}, {input})",
+        call="physicsobject::Size<Int_t>({df}, {output}, {input})",
         input=[q.good_bjet_collection],
         output=[q.nbtag],
     )


### PR DESCRIPTION
This pull request fixes the calculation of the number of jets, which leads to wrong results if `physicsobject::Count` is used. For the producers `NumberOfJets` and `NumberOfBJets`, the call of this function is replaced with `physicsobject::Size<int>`, which is going to be introduced with https://github.com/KIT-CMS/CROWN/pull/337.

Comment: The error occurs because `Nonzero` is used in `physicsobject::Count`, which leads to wrong results if the index 0 appears in a collection index list. This means that `Count` evaluates to `2` for an index list like `ROOT::RVec({0, 1, 2})`, instead of the true value of `3`.