### PR TITLE
Rework with new producer rules

### DIFF
--- a/config_run3.py
+++ b/config_run3.py
@@ -16,12 +16,17 @@ from .producers import taus as taus
 from .producers import triggers as triggers
 from .quantities import nanoAODv15
 from .quantities import output as q
-from .tau_triggersetup import add_diTauTriggerSetup
+from .tau_triggersetup import add_diTauTriggerSetup, RUN2_ERAS
 from .variations import add_Variations
 from .tau_embedding_settings import setup_embedding
 from code_generation.configuration import Configuration
 from code_generation.modifiers import EraModifier, SampleModifier
 from code_generation.rules import AppendProducer, RemoveProducer, ReplaceProducer
+
+# hadronic tau decay modes the analysis accepts
+# the selection masks cut on the very same list
+TAU_DECAY_MODES = "0,1,10,11"
+
 
 def build_config(
     era: str,
@@ -184,10 +189,6 @@ def build_config(
             # muon scale and resolution
             "muon_sr_file": EraModifier(
                 {
-                    "2016preVFP": "data/jsonpog-integration/POG/MUO/2016preVFP_UL/muon_scalesmearing.json.gz",
-                    "2016postVFP": "data/jsonpog-integration/POG/MUO/2016postVFP_UL/muon_scalesmearing.json.gz",
-                    "2017": "data/jsonpog-integration/POG/MUO/2017_UL/muon_scalesmearing.json.gz",
-                    "2018": "data/jsonpog-integration/POG/MUO/2018_UL/muon_scalesmearing.json.gz",
                     "2022preEE": "/cvmfs/cms-griddata.cern.ch/cat/metadata/MUO/Run3-22CDSep23-Summer22-NanoAODv12/2026-06-18/muon_scalesmearing.json.gz",
                     "2022postEE": "/cvmfs/cms-griddata.cern.ch/cat/metadata/MUO/Run3-22EFGSep23-Summer22EE-NanoAODv12/2026-06-18/muon_scalesmearing.json.gz",
                     "2023preBPix": "/cvmfs/cms-griddata.cern.ch/cat/metadata/MUO/Run3-23CSep23-Summer23-NanoAODv12/2026-06-18/muon_scalesmearing.json.gz",
@@ -195,7 +196,8 @@ def build_config(
                     "2024": "/cvmfs/cms-griddata.cern.ch/cat/metadata/MUO/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2026-06-18/muon_scalesmearing.json.gz",
                     "2025": "/cvmfs/cms-griddata.cern.ch/cat/metadata/MUO/Run3-25Prompt-Summer24-NanoAODv15/2026-04-28/muon_scalesmearing.json.gz",
                     "2026": "/cvmfs/cms-griddata.cern.ch/cat/metadata/MUO/Run3-25Prompt-Summer24-NanoAODv15/2026-04-28/muon_scalesmearing.json.gz",
-                }
+                },
+                default='""',  # not used for Run 2
             ),
             "muon_sr_shift": "nom", # or ScaleUp, ScaleDown, ResoUp, ResoDown
             
@@ -277,8 +279,8 @@ def build_config(
                     "2022postEE": "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22EFGSep23-Summer22EE-NanoAODv12/2026-06-05/jetid.json.gz",
                     "2023preBPix": "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23CSep23-Summer23-NanoAODv12/2026-06-05/jetid.json.gz",
                     "2023postBPix": "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23DSep23-Summer23BPix-NanoAODv12/2026-06-05/jetid.json.gz",
-                    "2024": "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2026-07-14/jetid.json.gz",
-                    "2025": "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-25Prompt-Summer24-NanoAODv15/2026-07-14/jetid.json.gz",
+                    "2024": "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2026-07-16/jetid.json.gz",
+                    "2025": "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-25Prompt-Summer24-NanoAODv15/2026-07-16/jetid.json.gz",
                     "2026": "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-26Prompt-Summer24-NanoAODv15/2026-07-15/jetid.json.gz",
                 },
                 default='""',  # not used for Run 2
@@ -294,8 +296,8 @@ def build_config(
                     "2022postEE": "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22EFGSep23-Summer22EE-NanoAODv12/2026-06-05/jet_jerc.json.gz",
                     "2023preBPix": "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23CSep23-Summer23-NanoAODv12/2026-06-05/jet_jerc.json.gz",
                     "2023postBPix": "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23DSep23-Summer23BPix-NanoAODv12/2026-06-05/jet_jerc.json.gz",
-                    "2024": "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2026-07-14/jet_jerc.json.gz",
-                    "2025": "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-25Prompt-Summer24-NanoAODv15/2026-07-14/jet_jerc.json.gz",
+                    "2024": "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2026-07-16/jet_jerc.json.gz",
+                    "2025": "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-25Prompt-Summer24-NanoAODv15/2026-07-16/jet_jerc.json.gz",
                     "2026": "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-26Prompt-Summer24-NanoAODv15/2026-07-15/jet_jerc.json.gz",
                 }
             ),
@@ -310,8 +312,8 @@ def build_config(
                     "2022postEE": "Summer22EE_22Sep2023_V4_DATA" if sample in ["embedding", "data"] else "Summer22EE_22Sep2023_V4_MC",
                     "2023preBPix": "Summer23Prompt23_V4_DATA" if sample in ["embedding", "data"] else "Summer23Prompt23_V4_MC",
                     "2023postBPix": "Summer23BPixPrompt23_V4_DATA" if sample in ["embedding", "data"] else "Summer23BPixPrompt23_V4_MC",
-                    "2024": "Summer24Prompt24_V4_DATA" if sample in ["embedding", "data"] else "Summer24Prompt24_V4_MC",
-                    "2025": "Summer24Prompt25_V2_DATA" if sample in ["embedding", "data"] else "Summer24Prompt25_V2_MC",
+                    "2024": "Summer24Prompt24_V5_DATA" if sample in ["embedding", "data"] else "Summer24Prompt24_V5_MC",
+                    "2025": "Summer24Prompt25_V3_DATA" if sample in ["embedding", "data"] else "Summer24Prompt25_V3_MC",
                     "2026": "Summer24Prompt26_V1_DATA" if sample in ["embedding", "data"] else "Summer24Prompt26_V1_MC",
                 }
             ),
@@ -355,8 +357,8 @@ def build_config(
                     "2022postEE": "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22EFGSep23-Summer22EE-NanoAODv12/2026-06-05/jetvetomaps.json.gz",
                     "2023preBPix": "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23CSep23-Summer23-NanoAODv12/2026-06-05/jetvetomaps.json.gz",
                     "2023postBPix": "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23DSep23-Summer23BPix-NanoAODv12/2026-06-05/jetvetomaps.json.gz",
-                    "2024": "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2026-07-14/jetvetomaps.json.gz",
-                    "2025": "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-25Prompt-Summer24-NanoAODv15/2026-07-14/jetvetomaps.json.gz",
+                    "2024": "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2026-07-16/jetvetomaps.json.gz",
+                    "2025": "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-25Prompt-Summer24-NanoAODv15/2026-07-16/jetvetomaps.json.gz",
                     "2026": "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-26Prompt-Summer24-NanoAODv15/2026-07-15/jetvetomaps.json.gz",
                 }
             ),
@@ -747,7 +749,7 @@ def build_config(
             ),
             "tau_vsjet_sf_dependence": "dm",
             #decay modes
-            "tau_dms": "0,1,10,11",
+            "tau_dms": TAU_DECAY_MODES,
             #energy scale
             "tau_ES_json_name": "tau_energy_scale",
             # genuine tau 
@@ -795,6 +797,9 @@ def build_config(
             "tau_elefake_es_DM1_endcap": "nom",
             "tau_elefake_es_DM10_endcap": "nom",
             "tau_elefake_es_DM11_endcap": "nom",
+            # vs ele id (Run2, non-DM-binned)
+            "tau_id_vsele_barrel": "nom",
+            "tau_id_vsele_endcap": "nom",
             # vs ele id
             "tau_id_vsele_DM0_barrel": "nom",
             "tau_id_vsele_DM1_barrel": "nom",
@@ -1009,6 +1014,9 @@ def build_config(
                 "max_muon_iso": 0.3,
                 "max_ele_iso": 0.3,
                 "jet_reapplyJES": False,
+                # Run 2 jet selection (GoodJets_Run2): no horn treatment, pt>30 and |eta|<4.7
+                "min_jet_pt": 30,
+                "max_jet_eta": 4.7,
             }
         )
         configuration.add_config_parameters(
@@ -1147,6 +1155,13 @@ def build_config(
         ]:
             configuration.add_config_parameters(chs, params)
 
+    # ee/mm carry no fake factor regions, so unlike et/mt/tt there is no need
+    # for a looser baseline object selection plus a separate anti-iso region:
+    # tighten the lepton isolation object cut directly, for both Run 2 and
+    # Run 3 (applied last so it wins over the Run 2 block above).
+    configuration.add_config_parameters(["mm"], {"max_muon_iso": 0.15})
+    configuration.add_config_parameters(["ee"], {"max_ele_iso": 0.15})
+
     ############################
     ######## Producers #########
     ############################
@@ -1164,29 +1179,28 @@ def build_config(
             event.PS_weight,
             muons.MuonPtCorrection,
             muons.BaseMuons,
-            electrons.ElectronPtCorrectionMC,
+            electrons.ElectronPtCorrectionMCSwitch.get(era),
             electrons.BaseElectrons,
             jets.GenJet,
             jets.JetSmearingSeed,
-            jets.JetBTagUParT,
-            jets.JetRho,
-            jets.JetID, 
+            jets.JetBTagSwitch.get(era),
+            jets.JetRhoSwitch.get(era),
+            jets.JetIDSwitch.get(era),
             jets.JetVetoMapVeto,
             jets.JetIDCut,
-            jets.JetEnergyCorrection,
+            jets.JetEnergyCorrectionSwitch.get(era),
             jets.JetPtCut_loose,
             jets.JetEtaCut_Max3,
             jets.LooseJets_LowEta,
             jets.LooseJets_HighEta,
             jets.GoodJets_loose,
             jets.GoodJets_tight,
-            jets.GoodJets,
-            jets.GoodBJets,
-            event.DiLeptonVeto,
+            jets.GoodJetsSwitch.get(era),
+            jets.GoodBJetsSwitch.get(era),
+            event.DiLeptonVetoSwitch.get(era),
             genparticles.CalculateGenBosonVector,
             genparticles.CalculateVisGenBosonVector,
-            met.MetBasics,
-            met.MetMask,
+            met.MetBasicsSwitch.get(era),
             event.EvenOddIDFlag,
         ],
     )
@@ -1197,12 +1211,12 @@ def build_config(
             jets.BasicJetQuantities, 
             jets.BJetCollection,
             jets.BasicBJetQuantities,
-            met.MetCorrections, 
-            met.PFMetCorrections,
+            met.MetCorrectionsSwitch.get(era),
+            met.PFMetCorrectionsSwitch.get(era),
             pairquantities.DiTauPairMETQuantities,
             pairquantities.DiObjectAngleQuantities,
             genparticles.GenMatching,
-            scalefactors.btaggingWP_SF,
+            scalefactors.btaggingWP_SFSwitch.get(era),
         ],
     )
     configuration.add_producers(
@@ -1212,21 +1226,21 @@ def build_config(
             muons.NumberOfGoodMuons,
             muons.VetoMuons,
             muons.ExtraMuonsVeto,
-            taus.TauEnergyCorrection,
-            taus.BaseTaus,
-            taus.GoodTaus,
+            taus.TauEnergyCorrectionSwitch.get(era),
+            taus.BaseTausSwitch.get(era),
+            taus.GoodTausSwitch.get(era),
             taus.NumberOfGoodTaus,
-            electrons.ExtraElectronsVeto, 
+            electrons.ExtraElectronsVeto,
             pairselection.MTPairSelection,
             pairselection.GoodMTPairFilter,
             pairselection.LVMu1,
             pairselection.LVTau2,
             pairselection.LVMu1Uncorrected,
             pairselection.LVTau2Uncorrected,
-            pairquantities.MTDiTauPairQuantities,
+            pairquantities.MTDiTauPairQuantitiesSwitch.get(era),
             genparticles.MTGenDiTauPairQuantities,
             scalefactors.MuonIDIso_SF,
-            scalefactors.TauID_SF,
+            scalefactors.TauID_SFSwitch.get(era),
             triggers.MTGenerateSingleMuonTriggerFlags,
             #triggers.MTGenerateCrossTriggerFlags,
             #triggers.GenerateSingleTrailingTauTriggerFlags,
@@ -1258,9 +1272,9 @@ def build_config(
         "et",
         [
             electrons.GoodElectrons,
-            taus.TauEnergyCorrection,
-            taus.BaseTaus,
-            taus.GoodTaus,
+            taus.TauEnergyCorrectionSwitch.get(era),
+            taus.BaseTausSwitch.get(era),
+            taus.GoodTausSwitch.get(era),
             taus.NumberOfGoodTaus,
             electrons.NumberOfGoodElectrons,
             electrons.VetoElectrons,
@@ -1272,9 +1286,9 @@ def build_config(
             pairselection.LVTau2,
             pairselection.LVEl1Uncorrected,
             pairselection.LVTau2Uncorrected,
-            pairquantities.ETDiTauPairQuantities,
+            pairquantities.ETDiTauPairQuantitiesSwitch.get(era),
             genparticles.ETGenDiTauPairQuantities,
-            scalefactors.TauID_SF,
+            scalefactors.TauID_SFSwitch.get(era),
             scalefactors.EleID_SF,
             triggers.ETGenerateSingleElectronTriggerFlags,
             #triggers.ETGenerateCrossTriggerFlags,
@@ -1336,9 +1350,9 @@ def build_config(
         [   
             electrons.ExtraElectronsVeto,
             muons.ExtraMuonsVeto,
-            taus.TauEnergyCorrection,
-            taus.BaseTaus,
-            taus.GoodTaus,
+            taus.TauEnergyCorrectionSwitch.get(era),
+            taus.BaseTausSwitch.get(era),
+            taus.GoodTausSwitch.get(era),
             taus.NumberOfGoodTaus,
             pairselection.TTPairSelection,
             pairselection.GoodTTPairFilter,
@@ -1346,9 +1360,9 @@ def build_config(
             pairselection.LVTau2,
             pairselection.LVTau1Uncorrected,
             pairselection.LVTau2Uncorrected,
-            pairquantities.TTDiTauPairQuantities,
+            pairquantities.TTDiTauPairQuantitiesSwitch.get(era),
             genparticles.TTGenDiTauPairQuantities,
-            scalefactors.TauID_SF,
+            scalefactors.TauID_SFSwitch.get(era),
             triggers.TTGenerateDoubleTauTriggerFlags,
             scalefactors.DoubleTauTriggerSF,
         ],
@@ -1358,18 +1372,18 @@ def build_config(
     ######### Modifications ########
     ################################
 
-    MC_ONLY = ["data", "embedding", "embedding_mc"]
+    DATA_ONLY = ["data", "embedding", "embedding_mc"]
     
     for mod_scopes, rule_cls, producers, sample_filter in [
-        ("global", RemoveProducer, [event.npartons], 
+        ("global", RemoveProducer, [event.npartons],
             {"exclude_samples": ["dyjets", "dyjets_powheg", "dyjets_amcatnlo", "dyjets_amcatnlo_ll", "dyjets_amcatnlo_tt", "wjets", "wjets_amcatnlo", "electroweak_boson"]}),
-        ("global", RemoveProducer, [event.PUweights, event.PS_weight], {"samples": MC_ONLY}),
-        ("global", RemoveProducer, [event.LHE_Scale_weight, event.LHE_PDF_weight, event.LHE_alphaS_weight], {"samples": MC_ONLY + ["diboson"]}),
-        (scopes, RemoveProducer, [scalefactors.btaggingWP_SF], {"samples": MC_ONLY}),
-        (scopes, RemoveProducer, [genparticles.GenMatching], {"samples": MC_ONLY}),
-        (["et", "mt", "tt"], RemoveProducer, [scalefactors.TauID_SF], {"samples": MC_ONLY}),
-        (["mt", "em", "mm"], RemoveProducer, [scalefactors.MuonIDIso_SF], {"samples": MC_ONLY}),
-        (["et", "ee", "em"], RemoveProducer, [scalefactors.EleID_SF], {"samples": MC_ONLY}),
+        ("global", RemoveProducer, [event.PUweights, event.PS_weight], {"samples": DATA_ONLY}),
+        ("global", RemoveProducer, [event.LHE_Scale_weight, event.LHE_PDF_weight, event.LHE_alphaS_weight], {"samples": DATA_ONLY + ["diboson"]}),
+        (scopes, RemoveProducer, [scalefactors.btaggingWP_SFSwitch.get(era)], {"samples": DATA_ONLY}),
+        (scopes, RemoveProducer, [genparticles.GenMatching], {"samples": DATA_ONLY}),
+        (["et", "mt", "tt"], RemoveProducer, [scalefactors.TauID_SFSwitch.get(era)], {"samples": DATA_ONLY}),
+        (["mt", "em", "mm"], RemoveProducer, [scalefactors.MuonIDIso_SF], {"samples": DATA_ONLY}),
+        (["et", "ee", "em"], RemoveProducer, [scalefactors.EleID_SF], {"samples": DATA_ONLY}),
         (["mt"], RemoveProducer, [genparticles.MTGenDiTauPairQuantities], {"samples": ["data"]}),
         (["mm"], RemoveProducer, [genparticles.MuMuGenPairQuantities], {"samples": ["data"]}),
         (["et"], RemoveProducer, [genparticles.ETGenDiTauPairQuantities], {"samples": ["data"]}),
@@ -1377,91 +1391,54 @@ def build_config(
         (["ee"], RemoveProducer, [genparticles.ElElGenPairQuantities], {"samples": ["data"]}),
         (["tt"], RemoveProducer, [genparticles.TTGenDiTauPairQuantities], {"samples": ["data"]}),
 
-        ("global", AppendProducer, [event.JSONFilter], {"samples": MC_ONLY}),
+        ("global", AppendProducer, [event.JSONFilter], {"samples": DATA_ONLY}),
         ## producer to add a cut on DYto2L affected by pythia bug where DYto2Tau has been reprocessed
         ("global", AppendProducer, [genparticles.GenDYFlavor, genparticles.GenDYFilter], {"samples": ["dyjets_amcatnlo_ll"]}),
         (scopes, AppendProducer, [event.ZPtReweighting], {"samples": ["dyjets_powheg", "dyjets_amcatnlo", "dyjets_amcatnlo_ll", "dyjets_amcatnlo_tt", "electroweak_boson"]}),
         (scopes, AppendProducer, [event.GGH_NNLO_Reweighting, event.GGH_WG1_Uncertainties], {"samples": ["ggh_htautau", "rem_htautau"]}),
         (scopes, AppendProducer, [event.QQH_WG1_Uncertainties], {"samples": ["vbf_htautau", "rem_htautau"]}),
-        (scopes, AppendProducer, [event.TopPtReweighting], {"samples": ["ttbar"]}),
-                
-        ("global", ReplaceProducer, [jets.GenJet, jets.GenJet_data], {"samples": MC_ONLY}),
-        (["et", "mt", "tt"], ReplaceProducer, [taus.TauEnergyCorrection, taus.TauEnergyCorrection_data], {"samples": MC_ONLY}),
-        
+        (scopes, AppendProducer, [event.TopPtReweightingSwitch.get(era)], {"samples": ["ttbar"]}),
+
+        ("global", ReplaceProducer, [jets.GenJet, jets.GenJet_data], {"samples": DATA_ONLY}),
+        ("global", ReplaceProducer, [electrons.ElectronPtCorrectionMCSwitch.get(era), electrons.ElectronPtCorrectionDataSwitch.get(era)], {"samples": DATA_ONLY}),
+        (["et", "mt", "tt"], ReplaceProducer, [taus.TauEnergyCorrectionSwitch.get(era), taus.TauEnergyCorrection_data], {"samples": DATA_ONLY}),
     ]:
         configuration.add_modification_rule(mod_scopes, rule_cls(producers=producers, **sample_filter))
 
-    if int(era[:4]) < 2022:
-        for mod_scopes, rule_cls, producers, sample_filter in [
-            ("global", RemoveProducer, [jets.JetVetoMapVeto], {"exclude_samples": ["fake_era"]}),
-            (["mt", "em", "mm"], RemoveProducer, [scalefactors.MuonIDIso_SF], {"exclude_samples": MC_ONLY}),
-            (["et", "ee", "em"], RemoveProducer, [scalefactors.EleID_SF], {"exclude_samples": MC_ONLY}),
-            (["mt"], RemoveProducer, [scalefactors.SingleMuTriggerSF], {"exclude_samples": ["fake_era"]}),
-            (["et"], RemoveProducer, [scalefactors.SingleEleTriggerSF], {"exclude_samples": ["fake_era"]}),
-            (["tt"], RemoveProducer, [scalefactors.DoubleTauTriggerSF], {"exclude_samples": ["fake_era"]}),
+    # Era specific modifications
+    for mod_scopes, rule_cls, producers, rule_filter in [
+        ("global", RemoveProducer, [jets.JetVetoMapVeto], {"eras": RUN2_ERAS}),
+        (["mt", "em", "mm"], RemoveProducer, [scalefactors.MuonIDIso_SF], {"exclude_samples": DATA_ONLY, "eras": RUN2_ERAS}),
+        (["et", "ee", "em"], RemoveProducer, [scalefactors.EleID_SF], {"exclude_samples": DATA_ONLY, "eras": RUN2_ERAS}),
+        (["mt"], RemoveProducer, [scalefactors.SingleMuTriggerSF], {"eras": RUN2_ERAS}),
+        (["et"], RemoveProducer, [scalefactors.SingleEleTriggerSF], {"eras": RUN2_ERAS}),
+        (["tt"], RemoveProducer, [scalefactors.DoubleTauTriggerSF], {"eras": RUN2_ERAS}),
 
-            # cross triggers and embedding triggers      
-            (["mt"], AppendProducer, [triggers.MTGenerateCrossTriggerFlags, triggers.GenerateSingleTrailingTauTriggerFlags], {"exclude_samples": ["fake_era"]}),
-            (["mt"], AppendProducer, [scalefactors.MTGenerateSingleMuonTriggerSF_MC, scalefactors.PrivateMuonIDSF_1_MC, scalefactors.PrivateMuonIsoSF_1_MC], {"exclude_samples": MC_ONLY}),
-            (["et"], AppendProducer, [triggers.ETGenerateCrossTriggerFlags, triggers.GenerateSingleTrailingTauTriggerFlags], {"exclude_samples": ["fake_era"]}),
-            (["et"], AppendProducer, [scalefactors.ETGenerateSingleElectronTriggerSF_MC, scalefactors.PrivateElectronIDSF_1_MC, scalefactors.PrivateElectronIsoSF_1_MC], {"exclude_samples": MC_ONLY}),
-            (["tt"], AppendProducer, [triggers.GenerateSingleTrailingTauTriggerFlags, triggers.GenerateSingleLeadingTauTriggerFlags], {"exclude_samples": ["fake_era"]}),
-            (["em"], AppendProducer, [scalefactors.PrivateElectronIDSF_1_MC, scalefactors.PrivateElectronIsoSF_1_MC, scalefactors.PrivateMuonIDSF_2_MC, scalefactors.PrivateMuonIsoSF_2_MC], {"exclude_samples": MC_ONLY}),
-            (["mm"], AppendProducer, [scalefactors.PrivateMuonIDSF_1_MC, scalefactors.PrivateMuonIsoSF_1_MC, scalefactors.PrivateMuonIDSF_2_MC, scalefactors.PrivateMuonIsoSF_2_MC, scalefactors.MTGenerateSingleMuonTriggerSF_MC], {"exclude_samples": MC_ONLY}),
-            (["ee"], AppendProducer, [scalefactors.PrivateElectronIDSF_1_MC, scalefactors.PrivateElectronIsoSF_1_MC, scalefactors.PrivateElectronIDSF_2_MC, scalefactors.PrivateElectronIsoSF_2_MC, scalefactors.ETGenerateSingleElectronTriggerSF_MC], {"exclude_samples": MC_ONLY}),
-                        
-            ("global", ReplaceProducer, [electrons.ElectronIDCut, electrons.ElectronIDCut_v9], {"exclude_samples": ["fake_era"]}),
-            ("global", ReplaceProducer, [event.TopPtReweighting, event.TopPtReweighting_Run2], {"samples": ["ttbar"]}),
-            ("global", ReplaceProducer, [electrons.ElectronPtCorrectionMC, electrons.ElectronPtCorrectionMC_v9], {"exclude_samples": MC_ONLY}),
-            ("global", ReplaceProducer, [electrons.ElectronPtCorrectionMC, electrons.RenameElectronPt], {"samples": MC_ONLY}),
-            ("global", ReplaceProducer, [event.DiLeptonVeto, event.DiLeptonVeto_v9], {"exclude_samples": ["fake_era"]}),
-            ("global", ReplaceProducer, [jets.JetEnergyCorrection, jets.JetEnergyCorrection_Run2], {"exclude_samples": MC_ONLY}),
-            ("global", ReplaceProducer, [jets.JetEnergyCorrection, jets.JetEnergyCorrection_data], {"samples": MC_ONLY}),
-            ("global", ReplaceProducer, [jets.JetID, jets.JetID_rename], {"exclude_samples": ["fake_era"]}),
-            ("global", ReplaceProducer, [jets.JetBTagUParT, jets.JetBTagDeep], {"exclude_samples": ["fake_era"]}),
-            ("global", ReplaceProducer, [jets.JetRho, jets.JetRho_v9], {"exclude_samples": ["fake_era"]}),
-            ("global", ReplaceProducer, [jets.GoodJets, jets.GoodJets_Run2], {"exclude_samples": ["fake_era"]}),
-            ("global", ReplaceProducer, [jets.GoodBJets, jets.GoodBJets_Run2], {"exclude_samples": ["fake_era"]}),
-            (scopes, ReplaceProducer, [scalefactors.btaggingWP_SF, scalefactors.btagging_SF], {"exclude_samples": MC_ONLY}),
-            (scopes, ReplaceProducer, [met.MetCorrections, met.MetCorrections_Run2], {"exclude_samples": ["fake_era"]}),
-            (scopes, ReplaceProducer, [met.PFMetCorrections, met.PFMetCorrections_Run2], {"exclude_samples": ["fake_era"]}),
-            (["mt", "et", "tt"], ReplaceProducer, [taus.BaseTaus, taus.BaseTaus_v9], {"exclude_samples": ["fake_era"]}),
-            (["mt", "et", "tt"], ReplaceProducer, [taus.GoodTaus, taus.GoodTaus_v9], {"exclude_samples": ["fake_era"]}),
-            (["mt", "et", "tt"], ReplaceProducer, [scalefactors.TauID_SF, scalefactors.TauID_SF_v9], {"exclude_samples": MC_ONLY}),
-            (["et", "mt", "tt"], ReplaceProducer, [taus.TauEnergyCorrection, taus.TauEnergyCorrection_ES_dm_pt_binned], {"exclude_samples": MC_ONLY}),
-            (["tt"], ReplaceProducer, [pairquantities.TTDiTauPairQuantities, pairquantities.TTDiTauPairQuantities_v9], {"exclude_samples": ["fake_era"]}),
-            (["mt"], ReplaceProducer, [pairquantities.MTDiTauPairQuantities, pairquantities.MTDiTauPairQuantities_v9], {"exclude_samples": ["fake_era"]}),
-            (["et"], ReplaceProducer, [pairquantities.ETDiTauPairQuantities, pairquantities.ETDiTauPairQuantities_v9], {"exclude_samples": ["fake_era"]}),
-        ]:
-            configuration.add_modification_rule(mod_scopes, rule_cls(producers=producers, **sample_filter))
+        # cross triggers and embedding triggers
+        (["mt"], AppendProducer, [triggers.MTGenerateCrossTriggerFlags, triggers.GenerateSingleTrailingTauTriggerFlags], {"eras": RUN2_ERAS}),
+        (["mt"], AppendProducer, [scalefactors.MTGenerateSingleMuonTriggerSF_MC, scalefactors.PrivateMuonIDSF_1_MC, scalefactors.PrivateMuonIsoSF_1_MC], {"exclude_samples": DATA_ONLY, "eras": RUN2_ERAS}),
+        (["et"], AppendProducer, [triggers.ETGenerateCrossTriggerFlags, triggers.GenerateSingleTrailingTauTriggerFlags], {"eras": RUN2_ERAS}),
+        (["et"], AppendProducer, [scalefactors.ETGenerateSingleElectronTriggerSF_MC, scalefactors.PrivateElectronIDSF_1_MC, scalefactors.PrivateElectronIsoSF_1_MC], {"exclude_samples": DATA_ONLY, "eras": RUN2_ERAS}),
+        (["tt"], AppendProducer, [triggers.GenerateSingleTrailingTauTriggerFlags, triggers.GenerateSingleLeadingTauTriggerFlags], {"eras": RUN2_ERAS}),
+        (["em"], AppendProducer, [triggers.EMGenerateCrossTriggerFlags], {"eras": RUN2_ERAS}),
+        (["em"], AppendProducer, [scalefactors.PrivateElectronIDSF_1_MC, scalefactors.PrivateElectronIsoSF_1_MC, scalefactors.PrivateMuonIDSF_2_MC, scalefactors.PrivateMuonIsoSF_2_MC], {"exclude_samples": DATA_ONLY, "eras": RUN2_ERAS}),
+        (["mm"], AppendProducer, [scalefactors.PrivateMuonIDSF_1_MC, scalefactors.PrivateMuonIsoSF_1_MC, scalefactors.PrivateMuonIDSF_2_MC, scalefactors.PrivateMuonIsoSF_2_MC, scalefactors.MTGenerateSingleMuonTriggerSF_MC], {"exclude_samples": DATA_ONLY, "eras": RUN2_ERAS}),
+        (["ee"], AppendProducer, [scalefactors.PrivateElectronIDSF_1_MC, scalefactors.PrivateElectronIsoSF_1_MC, scalefactors.PrivateElectronIDSF_2_MC, scalefactors.PrivateElectronIsoSF_2_MC, scalefactors.ETGenerateSingleElectronTriggerSF_MC], {"exclude_samples": DATA_ONLY, "eras": RUN2_ERAS}),
 
-        if era != "2018":
-            configuration.add_modification_rule("global", AppendProducer(producers=event.PrefireWeight, exclude_samples=["fake_era"],),)
+        ("global", ReplaceProducer, [electrons.ElectronIDCut, electrons.ElectronIDCut_v9], {"eras": RUN2_ERAS}),
+        ("global", ReplaceProducer, [jets.JetEnergyCorrectionSwitch.get(era), jets.JetEnergyCorrection_data], {"samples": DATA_ONLY, "eras": RUN2_ERAS}),
+        ("global", ReplaceProducer, [muons.MuonPtCorrection, muons.MuonPtCorrection_Run2], {"eras": RUN2_ERAS}),
+
+        ("global", AppendProducer, [event.PrefireWeight], {"eras": [e for e in RUN2_ERAS if e != "2018"]}),
         # Broken sfs file for 2016. If nlo is used, this reweighting is not even needed. !!!
-        if "2016" not in era:
-            configuration.add_modification_rule(scopes, AppendProducer(producers=event.ZPtReweighting_Run2, samples=["dyjets", "electroweak_boson"]),)
-    else:
-        configuration.add_modification_rule("global", ReplaceProducer(producers=[electrons.ElectronPtCorrectionMC, electrons.ElectronPtCorrectionData], samples=MC_ONLY,),)
+        (scopes, AppendProducer, [event.ZPtReweighting_Run2], {"samples": ["dyjets", "electroweak_boson"], "eras": [e for e in RUN2_ERAS if "2016" not in e]}),
 
-    if 2022 <= int(era[:4]) < 2024:
-        for mod_scopes, rule_cls, producers, sample_filter in [
-            ("global", ReplaceProducer, [jets.JetBTagUParT, jets.JetBTagPNet], {"exclude_samples": ["fake_era"]}),
-            ("global", ReplaceProducer, [jets.JetID, jets.JetIDRun3NanoV12Corrected], {"exclude_samples": ["fake_era"]}),
-            (scopes, ReplaceProducer, [met.MetCorrections, met.MetCorrections_v12], {"exclude_samples": ["fake_era"]}),
-            (["et", "mt", "tt"], ReplaceProducer, [taus.TauEnergyCorrection, taus.TauEnergyCorrection_v12], {"exclude_samples": MC_ONLY}),
-            (["mt", "et", "tt"], ReplaceProducer, [scalefactors.TauID_SF, scalefactors.TauID_SF_v12], {"exclude_samples": MC_ONLY}),
-        ]:
-            configuration.add_modification_rule(mod_scopes, rule_cls(producers=producers, **sample_filter))
-    
-    if int(era[:4]) < 2024:
-        configuration.add_modification_rule("global", ReplaceProducer(producers=[met.MetBasics, met.MetBasics_v12], exclude_samples=["fake_era"],),)
+        # separate MC for 2024 and 2025 by even/odd event number
+        ("global", AppendProducer, [event.EvenIDFilter], {"exclude_samples": DATA_ONLY, "eras": ["2024"]}),
+        ("global", AppendProducer, [event.OddIDFilter], {"exclude_samples": ["data", "embedding"], "eras": ["2025", "2026"]}),
+    ]:
+        configuration.add_modification_rule(mod_scopes, rule_cls(producers=producers, **rule_filter))
 
-    # separate MC for 2024 and 2025 by even/odd event number
-    if era == "2024":
-        configuration.add_modification_rule("global", AppendProducer(producers=[event.EvenIDFilter], exclude_samples=MC_ONLY,),)
-    if era == "2025" or era == "2026":
-        configuration.add_modification_rule("global", AppendProducer(producers=[event.OddIDFilter], exclude_samples=["data", "embedding"],),)
-    
 
     #########################
     ######## OUTPUTS ########
@@ -1488,7 +1465,6 @@ def build_config(
             q.ps_weight,
             q.lhe_pdf_weight,
             q.lhe_alphaS_weight,
-            q.met_mask,
             q.jet_ID,
             q.jet_vetomap,
             ] + [p for scope in scopes for p in genparticles.GenMatching.get_outputs(scope)] + [
@@ -1500,7 +1476,7 @@ def build_config(
             q.dilepton_veto,
             q.dielectron_veto,
             ] + [p for scope in scopes for p in pairquantities.DiObjectAngleQuantities.get_outputs(scope)
-            ] + [p for scope in scopes for p in met.MetCorrections.get_outputs(scope)
+            ] + [p for scope in scopes for p in met.MetCorrectionsSwitch.get(era).get_outputs(scope)
         ],
     )
     # add genWeight for everything but data
@@ -1525,7 +1501,7 @@ def build_config(
             q.dimuon_veto,
             q.extraelec_veto,
             ] + [p for p in genparticles.MTGenDiTauPairQuantities.get_outputs("mt")
-            ] + [p for p in scalefactors.TauID_SF.get_outputs("mt")
+            ] + [p for p in scalefactors.TauID_SFSwitch.get(era).get_outputs("mt")
         ],
     )
     configuration.add_outputs(
@@ -1547,7 +1523,7 @@ def build_config(
             q.dimuon_veto,
             q.extraelec_veto,
             ] + [p for p in genparticles.ETGenDiTauPairQuantities.get_outputs("et")
-            ] + [p for p in scalefactors.TauID_SF.get_outputs("et")
+            ] + [p for p in scalefactors.TauID_SFSwitch.get(era).get_outputs("et")
         ],
     )
     configuration.add_outputs(
@@ -1587,14 +1563,15 @@ def build_config(
             q.dimuon_veto,
             q.extraelec_veto,
             ] + [p for p in genparticles.TTGenDiTauPairQuantities.get_outputs("tt")
-            ] + [p for p in scalefactors.TauID_SF.get_outputs("tt")
+            ] + [p for p in scalefactors.TauID_SFSwitch.get(era).get_outputs("tt")
         ],
     )
 
-    if int(era[:4]) < 2024:
-        configuration.add_outputs("global", [p for p in met.MetBasics_v12.get_outputs("global")],)
-    else:
-        configuration.add_outputs("global", [p for p in met.MetBasics.get_outputs("global")],)
+    configuration.add_outputs("global", [p for p in met.MetBasicsSwitch.get(era).get_outputs("global")],)
+
+    configuration.add_outputs("mt", [p for p in pairquantities.MTDiTauPairQuantitiesSwitch.get(era).get_outputs("mt")],)
+    configuration.add_outputs("et", [p for p in pairquantities.ETDiTauPairQuantitiesSwitch.get(era).get_outputs("et")],)
+    configuration.add_outputs("tt", [p for p in pairquantities.TTDiTauPairQuantitiesSwitch.get(era).get_outputs("tt")],)
 
     if int(era[:4]) < 2022:
         configuration.add_outputs(
@@ -1602,7 +1579,6 @@ def build_config(
             [
                 triggers.MTGenerateCrossTriggerFlags.output_group,
                 triggers.GenerateSingleTrailingTauTriggerFlags.output_group,
-                ] + [p for p in pairquantities.MTDiTauPairQuantities_v9.get_outputs("mt")
             ],
         )
         configuration.add_outputs(
@@ -1610,7 +1586,6 @@ def build_config(
             [
                 triggers.ETGenerateCrossTriggerFlags.output_group,
                 triggers.GenerateSingleTrailingTauTriggerFlags.output_group,
-                ] + [p for p in pairquantities.ETDiTauPairQuantities_v9.get_outputs("et")
             ],
         )
         configuration.add_outputs(
@@ -1624,7 +1599,6 @@ def build_config(
             [
                 triggers.GenerateSingleTrailingTauTriggerFlags.output_group,
                 triggers.GenerateSingleLeadingTauTriggerFlags.output_group,
-                ] + [p for p in pairquantities.TTDiTauPairQuantities_v9.get_outputs("tt")
             ],
         )
     else:
@@ -1633,7 +1607,6 @@ def build_config(
             [
                 scalefactors.SingleMuTriggerSF.output_group,
                 ] + [p for p in scalefactors.MuonIDIso_SF.get_outputs("mt")
-                ] + [p for p in pairquantities.MTDiTauPairQuantities.get_outputs("mt")
             ],
         )
         configuration.add_outputs(
@@ -1641,15 +1614,11 @@ def build_config(
             [
                 scalefactors.SingleEleTriggerSF.output_group,
                 ] + [p for p in scalefactors.EleID_SF.get_outputs("et")
-                ] + [p for p in pairquantities.ETDiTauPairQuantities.get_outputs("et")
             ],
         )
         configuration.add_outputs(
             "tt",
-            [
-                p for p in scalefactors.DoubleTauTriggerSF.get_outputs("tt")
-                ] + [p for p in pairquantities.TTDiTauPairQuantities.get_outputs("tt")
-            ],
+            [p for p in scalefactors.DoubleTauTriggerSF.get_outputs("tt")],
         )
         configuration.add_outputs(
             "em",

--- a/generate.py
+++ b/generate.py
@@ -27,7 +27,6 @@ def run(args):
         "wjets_amcatnlo",
         "data",
         "electroweak_boson",
-        "fake_era",
     ]
     available_eras = [
         "2016preVFP", "2016postVFP", "2017", "2018", 

--- a/producers/electrons.py
+++ b/producers/electrons.py
@@ -1,6 +1,7 @@
 from ..quantities import output as q
 from ..quantities import nanoAODv15, nanoAODv9
 from ..scripts.CROWNWrapper import Producer, ProducerGroup, defaults
+from code_generation.producer import SwitchProducer
 
 ####################
 # Set of producers used for loosest selection of electrons
@@ -41,23 +42,31 @@ with defaults(scopes=["global"]):
             input=[nanoAODv15.Electron_pt],
         )
 
+    class ElectronPtCorrectionMCSwitch(SwitchProducer):
+        run2 = ElectronPtCorrectionMC_v9
+        run3 = ElectronPtCorrectionMC
+
+    class ElectronPtCorrectionDataSwitch(SwitchProducer):
+        run2 = RenameElectronPt
+        run3 = ElectronPtCorrectionData
+
     ElectronEtaCut = Producer(
-        call='''physicsobject::CutAbsMax<float>({df}, {output}, {input}, {max_ele_eta})''',
+        call='''physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {max_ele_eta})''',
         input=[nanoAODv15.Electron_eta],
         output=[q._ElectronEtaCut],
     )
     ElectronDxyCut = Producer(
-        call='''physicsobject::CutAbsMax<float>({df}, {output}, {input}, {max_ele_dxy})''',
+        call='''physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {max_ele_dxy})''',
         input=[nanoAODv15.Electron_dxy],
         output=[q._ElectronDxyCut],
     )
     ElectronDzCut = Producer(
-        call='''physicsobject::CutAbsMax<float>({df}, {output}, {input}, {max_ele_dz})''',
+        call='''physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {max_ele_dz})''',
         input=[nanoAODv15.Electron_dz],
         output=[q._ElectronDzCut],
     )
     ElectronPtCut= Producer(
-        call='''physicsobject::CutMin<float>({df}, {output}, {input}, {min_ele_pt})''',
+        call='''physicsobject::CutGreater<float>({df}, {output}, {input}, {min_ele_pt})''',
         input=[q.electron_pt_corrected],
         output=[q._ElectronPtCut],
     )
@@ -70,13 +79,13 @@ with defaults(scopes=["global"]):
         )
 
     ElectronIsoCut = Producer(
-        call='''physicsobject::CutMax<float>({df}, {output}, {input}, {max_ele_iso})''',
+        call='''physicsobject::CutSmaller<float>({df}, {output}, {input}, {max_ele_iso})''',
         input=[nanoAODv15.Electron_pfRelIso03_all],
         output=[q._ElectronIsoCut],
     )
 
     with defaults(output=[]):
-        DiElectronVetoPtCut = Producer(call='''physicsobject::CutMin<float>({df}, {output}, {input}, {min_dielectronveto_pt})''', input=[q.electron_pt_corrected])
+        DiElectronVetoPtCut = Producer(call='''physicsobject::CutGreater<float>({df}, {output}, {input}, {min_dielectronveto_pt})''', input=[q.electron_pt_corrected])
         DiElectronVetoIDCut = Producer(call='''physicsobject::CutMin<UChar_t>({df}, {output}, {input}, {dielectronveto_id_wp})''', input=[nanoAODv15.Electron_cutBased])
         DiElectronVetoIDCut_v9 = Producer(call='''physicsobject::CutMin<int>({df}, {output}, {input}, {dielectronveto_id_wp})''', input=[nanoAODv15.Electron_cutBased])
         DiElectronVetoElectrons = ProducerGroup(
@@ -149,9 +158,9 @@ with defaults(scopes=["global"]):
 
 with defaults(scopes=["em", "et", "ee"]):
     with defaults(output=[]):
-        GoodElectronPtCut = Producer(call='''physicsobject::CutMin<float>({df}, {output}, {input}, {min_ele_pt})''', input=[q.electron_pt_corrected])
-        GoodElectronEtaCut = Producer(call='''physicsobject::CutAbsMax<float>({df}, {output}, {input}, {max_ele_eta})''', input=[nanoAODv15.Electron_eta])
-        GoodElectronIsoCut = Producer(call='''physicsobject::CutMax<float>({df}, {output}, {input}, {max_ele_iso})''', input=[nanoAODv15.Electron_pfRelIso03_all])
+        GoodElectronPtCut = Producer(call='''physicsobject::CutGreater<float>({df}, {output}, {input}, {min_ele_pt})''', input=[q.electron_pt_corrected])
+        GoodElectronEtaCut = Producer(call='''physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {max_ele_eta})''', input=[nanoAODv15.Electron_eta])
+        GoodElectronIsoCut = Producer(call='''physicsobject::CutSmaller<float>({df}, {output}, {input}, {max_ele_iso})''', input=[nanoAODv15.Electron_pfRelIso03_all])
 
     GoodElectrons = ProducerGroup(
         call='''physicsobject::CombineMasks({df}, {output}, {input}, "all_of")''',

--- a/producers/event.py
+++ b/producers/event.py
@@ -4,6 +4,7 @@ from ..scripts.CROWNWrapper import BaseFilter, Producer, ProducerGroup, VectorPr
 from ..producers import electrons as electrons
 from ..producers import muons as muons
 from ..producers import genparticles as genparticles
+from code_generation.producer import SwitchProducer
 
 ####################
 # Set of general producers for event quantities
@@ -30,7 +31,10 @@ with defaults(scopes=["global"]):
             output=[q.dilepton_veto],
             subproducers=[electrons.DiElectronVeto_v9, muons.DiMuonVeto],
         )
-        # ---
+        class DiLeptonVetoSwitch(SwitchProducer):
+            run2 = DiLeptonVeto_v9
+            run3 = DiLeptonVeto
+
         SampleFlags_ProducerCollection = [
             is_data := Producer(call='''event::quantity::Define<bool>({df}, {output}, {is_data})''', output=[q.is_data]),
             is_embedding := Producer(call='''event::quantity::Define<bool>({df}, {output}, {is_embedding})''', output=[q.is_embedding]),
@@ -121,7 +125,7 @@ with defaults(scopes=["global", "em", "et", "mt", "tt", "mm", "ee"]):
     )
     # Run 2
     ZPtReweighting_Run2 = Producer(
-        call='''event::reweighting::ZPtMass({df}, {output}, {input}, "{zptmass_file}", "{zptmass_functor}", "{zptmass_arguments}")''',
+        call='''event::reweighting::ZPtMass({df}, {output}, {input}, "{zpt_file}", "{zptmass_functor}", "{zptmass_arguments}")''',
         input=[q.genboson_p4],
         output=[q.ZPtMassReweightWeight],
     )
@@ -134,6 +138,10 @@ with defaults(scopes=["global", "em", "et", "mt", "tt", "mm", "ee"]):
         ],
         output=[q.topPtReweightWeight],
     )
+
+    class TopPtReweightingSwitch(SwitchProducer):
+        run2 = TopPtReweighting_Run2
+        run3 = TopPtReweighting
 
     GGH_NNLO_Reweighting = Producer(
         call='''htxs::ggHNNLOWeights({df}, {output}, "{ggHNNLOweightsRootfile}", "{ggH_generator}", {input})''',

--- a/producers/jets.py
+++ b/producers/jets.py
@@ -1,6 +1,7 @@
 from ..quantities import output as q
 from ..quantities import nanoAODv15, nanoAODv12, nanoAODv9
 from ..scripts.CROWNWrapper import Producer, ProducerGroup, defaults
+from code_generation.producer import SwitchProducer
 
 ####################
 # Set of producers used for selection possible good jets
@@ -214,21 +215,20 @@ with defaults(scopes=["global"]):
         JetEnergyCorrection_data = ProducerGroup(subproducers=[JetPtCorrection_data, JetMassCorrection])
 
     with defaults(output=[]):
-        JetPtCut = Producer(call="physicsobject::CutMin<float>({df}, {output}, {input}, {min_jet_pt})", input=[q.jet_pt_corrected])
-        JetPtCut_loose = Producer(call='''physicsobject::CutMin<float>({df}, {output}, {input}, {min_jet_pt_loose})''', input=[q.jet_pt_corrected], output=[q.jet_pt_mask_loose])
-        JetPtCut_tight = Producer(call='''physicsobject::CutMin<float>({df}, {output}, {input}, {min_jet_pt_tight})''', input=[q.jet_pt_corrected])
+        JetPtCut = Producer(call="physicsobject::CutGreater<float>({df}, {output}, {input}, {min_jet_pt})", input=[q.jet_pt_corrected])
+        JetPtCut_loose = Producer(call='''physicsobject::CutGreater<float>({df}, {output}, {input}, {min_jet_pt_loose})''', input=[q.jet_pt_corrected], output=[q.jet_pt_mask_loose])
+        JetPtCut_tight = Producer(call='''physicsobject::CutGreater<float>({df}, {output}, {input}, {min_jet_pt_tight})''', input=[q.jet_pt_corrected])
         
-        JetEtaCut = Producer(call="physicsobject::CutAbsMax<float>({df}, {output}, {input}, {max_jet_eta})", input=[nanoAODv15.Jet_eta])
+        JetEtaCut = Producer(call="physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {max_jet_eta})", input=[nanoAODv15.Jet_eta])
         JetEtaCut_Min1 = Producer(call='''physicsobject::CutAbsMin<float>({df}, {output}, {input}, {jet_eta_1})''', input=[nanoAODv15.Jet_eta])
         JetEtaCut_Min2 = Producer(call='''physicsobject::CutAbsMin<float>({df}, {output}, {input}, {jet_eta_2})''', input=[nanoAODv15.Jet_eta])
-        JetEtaCut_Max1 = Producer(call='''physicsobject::CutAbsMax<float>({df}, {output}, {input}, {jet_eta_1})''', input=[nanoAODv15.Jet_eta])
-        JetEtaCut_Max2 = Producer(call='''physicsobject::CutAbsMax<float>({df}, {output}, {input}, {jet_eta_2})''', input=[nanoAODv15.Jet_eta])
-        JetEtaCut_Max3 = Producer(call='''physicsobject::CutAbsMax<float>({df}, {output}, {input}, {jet_eta_3})''', input=[nanoAODv15.Jet_eta], output=[q.jet_eta_mask_max])
+        JetEtaCut_Max1 = Producer(call='''physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {jet_eta_1})''', input=[nanoAODv15.Jet_eta])
+        JetEtaCut_Max2 = Producer(call='''physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {jet_eta_2})''', input=[nanoAODv15.Jet_eta])
+        JetEtaCut_Max3 = Producer(call='''physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {jet_eta_3})''', input=[nanoAODv15.Jet_eta], output=[q.jet_eta_mask_max])
 
-        BJetPtCut = Producer(call='''physicsobject::CutMin<float>({df}, {output}, {input}, {min_bjet_pt})''', input=[q.jet_pt_corrected])
-        BJetEtaCut = Producer(call='''physicsobject::CutAbsMax<float>({df}, {output}, {input}, {max_bjet_eta})''', input=[nanoAODv15.Jet_eta])
+        BJetPtCut = Producer(call='''physicsobject::CutGreater<float>({df}, {output}, {input}, {min_bjet_pt})''', input=[q.jet_pt_corrected])
+        BJetEtaCut = Producer(call='''physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {max_bjet_eta})''', input=[nanoAODv15.Jet_eta])
         BTagCut = Producer(call='''physicsobject::CutMin<float>({df}, {output}, {input}, {btag_cut})''', input=[q.jet_BTag])
-
 
     JetIDCut = Producer(
         call='''physicsobject::CutMin<int>({df}, {output}, {input}, {jet_id})''',
@@ -249,20 +249,20 @@ with defaults(scopes=["global"]):
         output=[q.loose_jets_mask_loweta],
         subproducers=[JetEtaCut_Max1],
     )
-    # pt>30 &  3 < |eta| < 4.7 & id
+    # pt>30 & 3 <= |eta| < 4.7 & id
     LooseJets_HighEta = ProducerGroup(
         call='''physicsobject::CombineMasks({df}, {output}, {input}, "all_of")''',
         input=[q.jet_id_mask, q.jet_pt_mask_loose, q.jet_eta_mask_max],
         output=[q.loose_jets_mask_higheta],
         subproducers=[JetEtaCut_Min2],
     )
-    # pt>30 & (|eta|<2.5 || 3<|eta|<4.7) & id
+    # pt>30 & (|eta| < 2.5 || 3 <= |eta| < 4.7) & id
     GoodJets_loose = Producer(
         call='''physicsobject::CombineMasks({df}, {output}, {input}, "any_of")''',
         input=[q.loose_jets_mask_loweta, q.loose_jets_mask_higheta],
         output=[q.good_jets_mask_loose],
     )
-    # pt>50 & 2.5<|eta|<3/4.7 (2022 and 2023) & id
+    # pt>50 & 2.5 <= |eta| < 3/4.7 (2022 and 2023) & id
     GoodJets_tight = ProducerGroup(
         call='''physicsobject::CombineMasks({df}, {output}, {input}, "all_of")''',
         input=[q.jet_id_mask],
@@ -271,7 +271,7 @@ with defaults(scopes=["global"]):
     )
     
     with defaults(call='''physicsobject::CombineMasks({df}, {output}, {input}, "any_of")'''):
-        # (pt>30 & (|eta|<2.5 || 3<|eta|<4.7) & id) || (pt>50 & 2.5<|eta|<3/4.7 (2022 and 2023) & id) for run 3
+        # (pt>30 & (|eta| < 2.5 || 3 <= |eta| < 4.7) & id) || (pt>50 & 2.5 <= |eta| < 3/4.7 (2022 and 2023) & id) for run 3
         GoodJets = Producer(
             input=[q.good_jets_mask_loose, q.good_jets_mask_tight],
             output=[q.good_jets_mask],
@@ -279,9 +279,9 @@ with defaults(scopes=["global"]):
     # run 2 without horn selection, pt>30 and eta<4.7
     GoodJets_Run2 = ProducerGroup(
         call='physicsobject::CombineMasks({df}, {output}, {input}, "all_of")',
-        input=[],
+        input=[q.jet_id_mask],  # JetIDCut is already run standalone in the global producer list
         output=[q.good_jets_mask],
-        subproducers=[JetPtCut, JetEtaCut, JetIDCut, JetPUIDCut],
+        subproducers=[JetPtCut, JetEtaCut, JetPUIDCut],
     )
 
     GoodBJets = ProducerGroup(
@@ -296,6 +296,34 @@ with defaults(scopes=["global"]):
         output=[q.good_bjets_mask],
         subproducers=[BJetPtCut, BJetEtaCut, BTagCut],
     )
+
+class JetBTagSwitch(SwitchProducer):
+    run2 = JetBTagDeep
+    class run3:
+        v12 = JetBTagPNet
+        v15 = JetBTagUParT
+
+class JetRhoSwitch(SwitchProducer):
+    run2 = JetRho_v9
+    run3 = JetRho
+
+class JetIDSwitch(SwitchProducer):
+    run2 = JetID_rename
+    class run3:
+        v12 = JetIDRun3NanoV12Corrected
+        v15 = JetID
+
+class JetEnergyCorrectionSwitch(SwitchProducer):
+    run2 = JetEnergyCorrection_Run2
+    run3 = JetEnergyCorrection
+
+class GoodJetsSwitch(SwitchProducer):
+    run2 = GoodJets_Run2
+    run3 = GoodJets
+
+class GoodBJetsSwitch(SwitchProducer):
+    run2 = GoodBJets_Run2
+    run3 = GoodBJets
 
 ####################
 # Set of producers to apply a veto of jets overlapping with ditaupair candidates and ordering jets by their pt

--- a/producers/met.py
+++ b/producers/met.py
@@ -3,6 +3,7 @@ from code_generation.quantity import NanoAODQuantity
 from ..quantities import output as q
 from ..quantities import nanoAODv15, nanoAODv12, nanoAODv9
 from ..scripts.CROWNWrapper import Producer, ProducerGroup, defaults
+from code_generation.producer import SwitchProducer
 
 ####################
 # Set of producers used for contruction of met related quantities
@@ -78,12 +79,6 @@ with defaults(scopes=["global"]):
             MetCov11_v12,
             MetSumEt,
         ],
-    )
-
-    MetMask = Producer(
-        call='''event::quantity::MinFlag<float>({df}, {output}, {input}, 0)''',
-        input=[nanoAODv15.PuppiMET_ptUnclusteredUp],
-        output=[q.met_mask],
     )
 
 with defaults(scopes=["et", "mt", "tt", "em", "mm", "ee"]):
@@ -164,7 +159,7 @@ with defaults(scopes=["et", "mt", "tt", "em", "mm", "ee"]):
             output=[q.pfmet_p4_recoilcorrected],
         )
 
-    with defaults(call='''met::RecoilCorrection({df}, {output}, {input}, "{recoil_corrections_file}", "{recoil_systematics_file}",, {applyRecoilCorrections}, {apply_recoil_resolution_systematic}, {apply_recoil_response_systematic}, "{recoil_systematic_shift_up}", "{recoil_systematic_shift_down}", {is_wjets})'''):
+    with defaults(call='''met::RecoilCorrection({df}, {output}, {input}, "{recoil_corrections_file}", "{recoil_systematics_file}", {applyRecoilCorrections}, {apply_recoil_resolution_systematic}, {apply_recoil_response_systematic}, "{recoil_systematic_shift_up}", "{recoil_systematic_shift_down}", {is_wjets})'''):
         ApplyRecoilCorrections_Run2 = Producer(
             input=[q.puppimet_p4_leptoncorrected, q.genboson_p4, q.visgenboson_p4, q.jet_pt_corrected],
             output=[q.puppimet_p4_recoilcorrected],
@@ -245,3 +240,19 @@ with defaults(scopes=["et", "mt", "tt", "em", "mm", "ee"]):
                 PFMetPhi,
             ],
         )
+
+    class MetCorrectionsSwitch(SwitchProducer):
+        run2 = MetCorrections_Run2
+        class run3:
+            v12 = MetCorrections_v12
+            v15 = MetCorrections
+
+    class PFMetCorrectionsSwitch(SwitchProducer):
+        run2 = PFMetCorrections_Run2
+        run3 = PFMetCorrections
+
+class MetBasicsSwitch(SwitchProducer):
+    run2 = MetBasics_v12
+    class run3:
+        v12 = MetBasics_v12
+        v15 = MetBasics

--- a/producers/muons.py
+++ b/producers/muons.py
@@ -12,24 +12,29 @@ with defaults(scopes=["global"]):
         input=[nanoAOD.Muon_pt, nanoAOD.Muon_eta, nanoAOD.Muon_phi, nanoAOD.Muon_charge, nanoAOD.Muon_nTrackerLayers, nanoAOD.luminosityBlock, nanoAOD.event],
         output=[q.muon_pt_corrected]
     )
+    MuonPtCorrection_Run2 = Producer(
+        call='''event::quantity::Rename<ROOT::RVec<float>>({df}, {output}, {input})''',
+        input=[nanoAOD.Muon_pt],
+        output=[q.muon_pt_corrected]
+    )
 
     MuonPtCut = Producer(
-        call='''physicsobject::CutMin<float>({df}, {output}, {input}, {min_muon_pt})''',
+        call='''physicsobject::CutGreater<float>({df}, {output}, {input}, {min_muon_pt})''',
         input=[q.muon_pt_corrected],
         output=[q._MuonPtCut],
     )
     MuonEtaCut = Producer(
-        call='''physicsobject::CutAbsMax<float>({df}, {output}, {input}, {max_muon_eta})''',
+        call='''physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {max_muon_eta})''',
         input=[nanoAOD.Muon_eta],
         output=[q._MuonEtaCut],
     )
     MuonDxyCut = Producer(
-        call='''physicsobject::CutAbsMax<float>({df}, {output}, {input}, {max_muon_dxy})''',
+        call='''physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {max_muon_dxy})''',
         input=[nanoAOD.Muon_dxy],
         output=[q._MuonDxyCut],
     )
     MuonDzCut = Producer(
-        call='''physicsobject::CutAbsMax<float>({df}, {output}, {input}, {max_muon_dz})''',
+        call='''physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {max_muon_dz})''',
         input=[nanoAOD.Muon_dz],
         output=[q._MuonDzCut],
     )
@@ -39,13 +44,13 @@ with defaults(scopes=["global"]):
         output=[q._MuonIDCut],
     )
     MuonIsoCut = Producer(
-        call='''physicsobject::CutMax<float>({df}, {output}, {input}, {max_muon_iso})''',
+        call='''physicsobject::CutSmaller<float>({df}, {output}, {input}, {max_muon_iso})''',
         input=[nanoAOD.Muon_pfRelIso04_all],
         output=[q._MuonIsoCut],
     )
 
     with defaults(output=[]):
-        DiMuonVetoPtCut = Producer(call='''physicsobject::CutMin<float>({df}, {output}, {input}, {min_dimuonveto_pt})''', input=[q.muon_pt_corrected])
+        DiMuonVetoPtCut = Producer(call='''physicsobject::CutGreater<float>({df}, {output}, {input}, {min_dimuonveto_pt})''', input=[q.muon_pt_corrected])
         DiMuonVetoIDCut = Producer(call='''physicsobject::CutEqual<bool>({df}, {output}, {input}, true)''', input=[nanoAOD.Muon_looseId])
         DiMuonVetoMuons = ProducerGroup(
             call='''physicsobject::CombineMasks({df}, {output}, {input}, "all_of")''',
@@ -85,11 +90,11 @@ with defaults(scopes=["global"]):
 
 with defaults(scopes=["em", "mt", "mm"]):
     with defaults(output=[]):
-        GoodMuonPtCut = Producer(call='''physicsobject::CutMin<float>({df}, {output}, {input}, {min_muon_pt})''', input=[q.muon_pt_corrected])
-        GoodMuonEtaCut = Producer(call='''physicsobject::CutAbsMax<float>({df}, {output}, {input}, {max_muon_eta})''', input=[nanoAOD.Muon_eta])
-        GoodMuonIsoCut = Producer(call='''physicsobject::CutMax<float>({df}, {output}, {input}, {max_muon_iso})''', input=[nanoAOD.Muon_pfRelIso04_all])
-        GoodMuonDzCut = Producer(call='''physicsobject::CutAbsMax<float>({df}, {output}, {input}, {max_muon_dz})''', input=[nanoAOD.Muon_dz])
-        GoodMuonDxyCut = Producer(call='''physicsobject::CutAbsMax<float>({df}, {output}, {input}, {max_muon_dxy})''', input=[nanoAOD.Muon_dxy])
+        GoodMuonPtCut = Producer(call='''physicsobject::CutGreater<float>({df}, {output}, {input}, {min_muon_pt})''', input=[q.muon_pt_corrected])
+        GoodMuonEtaCut = Producer(call='''physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {max_muon_eta})''', input=[nanoAOD.Muon_eta])
+        GoodMuonIsoCut = Producer(call='''physicsobject::CutSmaller<float>({df}, {output}, {input}, {max_muon_iso})''', input=[nanoAOD.Muon_pfRelIso04_all])
+        GoodMuonDzCut = Producer(call='''physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {max_muon_dz})''', input=[nanoAOD.Muon_dz])
+        GoodMuonDxyCut = Producer(call='''physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {max_muon_dxy})''', input=[nanoAOD.Muon_dxy])
 
     with defaults(
         call='''physicsobject::CombineMasks({df}, {output}, {input}, "all_of")''',

--- a/producers/pairquantities.py
+++ b/producers/pairquantities.py
@@ -6,6 +6,7 @@ from ..scripts.CROWNWrapper import (
     ExtendedVectorProducer,
     defaults,
 )
+from code_generation.producer import SwitchProducer
 
 
 ####################
@@ -403,6 +404,19 @@ with defaults(call=None, input=None, output=None):
         scopes=["et"],
         subproducers=[UnrollElLV1, UnrollTauLV2_v9, tau_decaymode_1_notau] + DiTauPairQuantitiesCollection + Flag_Collection_2_v9,
     )
+
+    class TTDiTauPairQuantitiesSwitch(SwitchProducer):
+        run2 = TTDiTauPairQuantities_v9
+        run3 = TTDiTauPairQuantities
+
+    class MTDiTauPairQuantitiesSwitch(SwitchProducer):
+        run2 = MTDiTauPairQuantities_v9
+        run3 = MTDiTauPairQuantities
+
+    class ETDiTauPairQuantitiesSwitch(SwitchProducer):
+        run2 = ETDiTauPairQuantities_v9
+        run3 = ETDiTauPairQuantities
+
     MuMuPairQuantities = ProducerGroup(
         scopes=["mm"],
         subproducers=[

--- a/producers/photons.py
+++ b/producers/photons.py
@@ -9,11 +9,11 @@ from ..scripts.CROWNWrapper import Producer, ProducerGroup, defaults
 with defaults(scopes=["global"]):
     with defaults(output=[]):
         PhotonPtCut = Producer(
-            call='''physicsobject::CutMin<float>({df}, {output}, {input}, {min_photon_pt})''',
+            call='''physicsobject::CutGreater<float>({df}, {output}, {input}, {min_photon_pt})''',
             input=[nanoAOD.Photon_pt],
         )
         PhotonEtaCut = Producer(
-            call='''physicsobject::CutAbsMax<float>({df}, {output}, {input}, {max_photon_eta})''',
+            call='''physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {max_photon_eta})''',
             input=[nanoAOD.Photon_eta],
         )
         PhotonElectronVeto = Producer(

--- a/producers/scalefactors.py
+++ b/producers/scalefactors.py
@@ -1,6 +1,7 @@
 from ..quantities import output as q
 from ..quantities import nanoAODv15 as nanoAOD
 from ..scripts.CROWNWrapper import Producer, ProducerGroup, ExtendedVectorProducer, defaults
+from code_generation.producer import SwitchProducer
 
 
 ############################
@@ -520,7 +521,7 @@ with defaults(scopes=["ee"], input=[q.pt_2, q.eta_2, q.phi_2]):
     )
 
 ETGenerateSingleElectronTriggerSF_MC = ExtendedVectorProducer(  # --- from our measurement ---
-    call='''embedding::electron::Scalefactor({df}, correctionManager, {output}, {input}, "{mc_electron_sf_file}", "{mc_trigger_sf}", "mc", "{mc_trg_extrapolation}")''',
+    call='''embedding::electron::Scalefactor({df}, correctionManager, {output}, {input}, "{mc_electron_sf_file}", "{mc_trigger_sf}", "mc", {mc_trg_extrapolation})''',
     input=[q.pt_1, q.eta_1],
     output="flagname",
     scopes=["et", "ee"],
@@ -812,3 +813,14 @@ with defaults(call=None, input=None, output=None):
             "et": [Ele_1_IDWP90_SF, Ele_1_IDWP80_SF],
         },
     )
+
+# need to keep the group producers since they are referenced individually too for variations and such
+class TauID_SFSwitch(SwitchProducer):
+    run2 = TauID_SF_v9
+    class run3:
+        v12 = TauID_SF_v12
+        v15 = TauID_SF
+
+class btaggingWP_SFSwitch(SwitchProducer):
+    run2 = btagging_SF
+    run3 = btaggingWP_SF

--- a/producers/taus.py
+++ b/producers/taus.py
@@ -1,19 +1,20 @@
 from ..quantities import output as q
 from ..quantities import nanoAODv15, nanoAODv9
 from ..scripts.CROWNWrapper import Producer, ProducerGroup, ExtendedVectorProducer, defaults
+from code_generation.producer import SwitchProducer
 
 
 with defaults(scopes=["global"], output=[]):
     TauPtCut = Producer(
-        call='''physicsobject::CutMin<float>({df}, {output}, {input}, {min_tau_pt})''',
+        call='''physicsobject::CutGreater<float>({df}, {output}, {input}, {min_tau_pt})''',
         input=[q.tau_pt_corrected],
     )
     TauEtaCut = Producer(
-        call='''physicsobject::CutAbsMax<float>({df}, {output}, {input}, {max_tau_eta})''',
+        call='''physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {max_tau_eta})''',
         input=[nanoAODv15.Tau_eta],
     )
     TauDzCut = Producer(
-        call='''physicsobject::CutAbsMax<float>({df}, {output}, {input}, {max_tau_dz})''',
+        call='''physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {max_tau_dz})''',
         input=[nanoAODv15.Tau_dz],
     )
 
@@ -406,15 +407,15 @@ with defaults(scopes=["et", "mt", "tt"]):
 
     with defaults(output=[]):
         GoodTauPtCut = Producer(
-            call='''physicsobject::CutMin<float>({df}, {output}, {input}, {min_tau_pt})''',
+            call='''physicsobject::CutGreater<float>({df}, {output}, {input}, {min_tau_pt})''',
             input=[q.tau_pt_corrected],
         )
         GoodTauEtaCut = Producer(
-            call='''physicsobject::CutAbsMax<float>({df}, {output}, {input}, {max_tau_eta})''',
+            call='''physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {max_tau_eta})''',
             input=[nanoAODv15.Tau_eta],
         )
         GoodTauDzCut = Producer(
-            call='''physicsobject::CutAbsMax<float>({df}, {output}, {input}, {max_tau_dz})''',
+            call='''physicsobject::CutAbsSmaller<float>({df}, {output}, {input}, {max_tau_dz})''',
             input=[nanoAODv15.Tau_dz],
         )
         GoodTauDMCut = Producer(
@@ -487,3 +488,18 @@ with defaults(scopes=["et", "mt", "tt"]):
         input=[q.good_taus_mask],
         output=[q.ntaus],
     )
+
+# need to keep group producers because of variations changing them differently and other methods
+class BaseTausSwitch(SwitchProducer):
+    run2 = BaseTaus_v9
+    run3 = BaseTaus
+
+class GoodTausSwitch(SwitchProducer):
+    run2 = GoodTaus_v9
+    run3 = GoodTaus
+
+class TauEnergyCorrectionSwitch(SwitchProducer):
+    run2 = TauEnergyCorrection_ES_dm_pt_binned
+    class run3:
+        v12 = TauEnergyCorrection_v12
+        v15 = TauEnergyCorrection

--- a/tau_triggersetup.py
+++ b/tau_triggersetup.py
@@ -1,68 +1,8 @@
 from code_generation.configuration import Configuration
 from code_generation.modifiers import EraModifier, SampleModifier
 
-MUTAU_CROSS_TRIGGER_FLAG = EraModifier(
-    {
-        "2016preVFP": "trg_cross_mu20tau27_hps",
-        "2016postVFP": "trg_cross_mu20tau27_hps",
-        "2017": "trg_cross_mu20tau27_hps",
-        "2018": "trg_cross_mu20tau27_hps",
-        "2022preEE": "trg_cross_mu20tau27_hps",
-        "2022postEE": "trg_cross_mu20tau27_hps",
-        "2023preBPix": "trg_cross_mu20tau27_hps",
-        "2023postBPix": "trg_cross_mu20tau27_hps",
-        "2024": "trg_cross_mu20tau27_hps",
-        "2025": "trg_cross_mu20tau27_pnet",
-        "2026": "trg_cross_mu20tau27_pnet",
-    }
-)
-
-ELETAU_CROSS_TRIGGER_FLAG = EraModifier(
-    {
-        "2016preVFP": "trg_cross_ele24tau30_hps",
-        "2016postVFP": "trg_cross_ele24tau30_hps",
-        "2017": "trg_cross_ele24tau30_hps",
-        "2018": "trg_cross_ele24tau30_hps",
-        "2022preEE": "trg_cross_ele24tau30_hps",
-        "2022postEE": "trg_cross_ele24tau30_hps",
-        "2023preBPix": "trg_cross_ele24tau30_hps",
-        "2023postBPix": "trg_cross_ele24tau30_hps",
-        "2024": "trg_cross_ele24tau30_hps",
-        "2025": "trg_cross_ele24tau30_pnet",
-        "2026": "trg_cross_ele24tau30_pnet",
-    }
-)
-
 RUN2_ERAS = ["2016preVFP", "2016postVFP", "2017", "2018"]
 DOUBLETAU_HPS_ERAS = ["2022preEE", "2022postEE", "2023preBPix", "2023postBPix"]
-
-# hps->pnet transition in 2025, shared by both legs and by nominal/shifted ditau SF blocks
-DOUBLETAU_TRIGGER_LEG1_FLAGNAME = EraModifier(
-    {
-        **{era: '""' for era in RUN2_ERAS},
-        **{era: "trg_wgt_doubletau35_leg1" for era in DOUBLETAU_HPS_ERAS},
-    },
-    default="trg_wgt_doubletau30_leg1",  # 2024, 2025, 2026
-)
-DOUBLETAU_TRIGGER_LEG2_FLAGNAME = EraModifier(
-    {
-        **{era: '""' for era in RUN2_ERAS},
-        **{era: "trg_wgt_doubletau35_leg2" for era in DOUBLETAU_HPS_ERAS},
-    },
-    default="trg_wgt_doubletau30_leg2",  # 2024, 2025, 2026
-)
-DOUBLETAU_TRIGGER_FLAG = EraModifier(
-    {
-        **{era: '""' for era in RUN2_ERAS},
-        **{era: "trg_double_tau35_mediumiso_hps" for era in DOUBLETAU_HPS_ERAS},
-    },
-    default="trg_double_tau30_mediumiso_pnet",  # 2024, 2025, 2026
-)
-DOUBLETAU_TRIGGER_SF_NAME = EraModifier(
-    {era: '""' for era in RUN2_ERAS},
-    default="ditau",  # all Run 3 eras
-)
-
 
 def add_diTauTriggerSetup(configuration: Configuration) -> Configuration:
 
@@ -727,7 +667,8 @@ def add_diTauTriggerSetup(configuration: Configuration) -> Configuration:
                         {
                             "flagname": "trg_cross_mu23ele12",
                             "hlt_path": "HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ",
-                            "p1_ptcut": 12,
+                            # p1_ptcut raised from the HLT-native 12 to 15: the offline em preselection (matches smhtt_ul) needs at least 15 on the electron leg
+                            "p1_ptcut": 15,
                             "p2_ptcut": 24,
                             **elmu_cross_trigger_defaults,
                         },
@@ -735,7 +676,8 @@ def add_diTauTriggerSetup(configuration: Configuration) -> Configuration:
                             "flagname": "trg_cross_mu8ele23",
                             "hlt_path": "HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ",
                             "p1_ptcut": 24,
-                            "p2_ptcut": 8,
+                            # p2_ptcut raised from the HLT-native 8 to 15: the offline em preselection (matches smhtt_ul) needs at least 15 on the muon leg
+                            "p2_ptcut": 15,
                             **elmu_cross_trigger_defaults,
                         },
                     ],
@@ -973,7 +915,7 @@ def add_diTauTriggerSetup(configuration: Configuration) -> Configuration:
     configuration.add_config_parameters(
         ["ee"],
         {
-            "doubleelectron_trigger": doubleelectron_trigger_defaults,
+            "doubleelectron_trigger": [doubleelectron_trigger_defaults],
         },
     )
 
@@ -1016,7 +958,11 @@ def add_diTauTriggerSetup(configuration: Configuration) -> Configuration:
             "mutau_trigger_leg1_sf": [
                 {
                     "mutau_cross_trigger_leg1_flagname": "trg_wgt_mu20tau27_leg1",
-                    "mutau_cross_trigger_flag": MUTAU_CROSS_TRIGGER_FLAG,
+                    "mutau_cross_trigger_flag": EraModifier(
+                        {"2025": "trg_cross_mu20tau27_pnet", 
+                         "2026": "trg_cross_mu20tau27_pnet"},
+                        default="trg_cross_mu20tau27_hps",
+                    ),
                     "mutau_cross_trigger_leg1_sf_name": "NUM_IsoMu20_DEN_CutBasedIdTight_and_PFIsoTight",
                     "mutau_cross_trigger_leg1_variation": "nominal",
                 },
@@ -1024,7 +970,11 @@ def add_diTauTriggerSetup(configuration: Configuration) -> Configuration:
             "mutau_trigger_leg2_sf": [
                 {
                     "mutau_cross_trigger_leg2_flagname": "trg_wgt_mu20tau27_leg2",
-                    "mutau_cross_trigger_flag": MUTAU_CROSS_TRIGGER_FLAG,
+                    "mutau_cross_trigger_flag": EraModifier(
+                        {"2025": "trg_cross_mu20tau27_pnet", 
+                         "2026": "trg_cross_mu20tau27_pnet"},
+                        default="trg_cross_mu20tau27_hps",
+                    ),
                     "mutau_cross_trigger_leg2_sf_name": "mutau",
                     "mutau_cross_trigger_leg2_variation": "nom",
                 },
@@ -1083,7 +1033,11 @@ def add_diTauTriggerSetup(configuration: Configuration) -> Configuration:
             ),
             "eletau_cross_trigger_leg1_sf": [
                 {
-                    "eletau_cross_trigger_flag": ELETAU_CROSS_TRIGGER_FLAG,
+                    "eletau_cross_trigger_flag": EraModifier(
+                        {"2025": "trg_cross_ele24tau30_pnet", 
+                         "2026": "trg_cross_ele24tau30_pnet"},
+                        default="trg_cross_ele24tau30_hps",
+                    ),
                     "eletau_cross_trigger_leg1_flagname": "trg_wgt_ele24tau30_leg1",
                     "eletau_cross_trigger_leg1_sf_name": "Electron-HLT-SF",
                     "eletau_cross_trigger_leg1_path_id_name": "HLT_SF_Ele24_TightID",
@@ -1093,7 +1047,11 @@ def add_diTauTriggerSetup(configuration: Configuration) -> Configuration:
             "eletau_cross_trigger_leg2_sf": [
                 {
                     "eletau_cross_trigger_leg2_flagname": "trg_wgt_ele24tau30_leg2",
-                    "eletau_cross_trigger_flag": ELETAU_CROSS_TRIGGER_FLAG,
+                    "eletau_cross_trigger_flag": EraModifier(
+                        {"2025": "trg_cross_ele24tau30_pnet", 
+                         "2026": "trg_cross_ele24tau30_pnet"},
+                        default="trg_cross_ele24tau30_hps",
+                    ),
                     "eletau_cross_trigger_leg2_sf_name": "etau",
                     "eletau_cross_trigger_leg2_variation": "nom",
                 },
@@ -1107,17 +1065,41 @@ def add_diTauTriggerSetup(configuration: Configuration) -> Configuration:
         {
             "doubletau_trigger_leg1_sf": [
                 {
-                    "doubletau_trigger_leg1_flagname": DOUBLETAU_TRIGGER_LEG1_FLAGNAME,
-                    "doubletau_trigger_flag": DOUBLETAU_TRIGGER_FLAG,
-                    "doubletau_trigger_leg1_sf_name": DOUBLETAU_TRIGGER_SF_NAME,
+                    "doubletau_trigger_leg1_flagname": EraModifier(
+                        {
+                            **{era: '""' for era in RUN2_ERAS},
+                            **{era: "trg_wgt_doubletau35_leg1" for era in DOUBLETAU_HPS_ERAS},
+                        },
+                        default="trg_wgt_doubletau30_leg1",  # 2024, 2025, 2026
+                    ),
+                    "doubletau_trigger_flag": EraModifier(
+                        {
+                            **{era: '""' for era in RUN2_ERAS},
+                            **{era: "trg_double_tau35_mediumiso_hps" for era in DOUBLETAU_HPS_ERAS},
+                        },
+                        default="trg_double_tau30_mediumiso_pnet",  # 2024, 2025, 2026
+                    ),
+                    "doubletau_trigger_leg1_sf_name": "ditau",
                     "doubletau_trigger_leg1_variation": "nom",
                 },
             ],
             "doubletau_trigger_leg2_sf": [
                 {
-                    "doubletau_trigger_leg2_flagname": DOUBLETAU_TRIGGER_LEG2_FLAGNAME,
-                    "doubletau_trigger_flag": DOUBLETAU_TRIGGER_FLAG,
-                    "doubletau_trigger_leg2_sf_name": DOUBLETAU_TRIGGER_SF_NAME,
+                    "doubletau_trigger_leg2_flagname": EraModifier(
+                        {
+                            **{era: '""' for era in RUN2_ERAS},
+                            **{era: "trg_wgt_doubletau35_leg2" for era in DOUBLETAU_HPS_ERAS},
+                        },
+                        default="trg_wgt_doubletau30_leg2",  # 2024, 2025, 2026
+                    ),
+                    "doubletau_trigger_flag": EraModifier(
+                        {
+                            **{era: '""' for era in RUN2_ERAS},
+                            **{era: "trg_double_tau35_mediumiso_hps" for era in DOUBLETAU_HPS_ERAS},
+                        },
+                        default="trg_double_tau30_mediumiso_pnet",  # 2024, 2025, 2026
+                    ),
+                    "doubletau_trigger_leg2_sf_name": "ditau",
                     "doubletau_trigger_leg2_variation": "nom",
                 },
             ],

--- a/variations.py
+++ b/variations.py
@@ -15,12 +15,7 @@ from .producers import taus as taus
 from .quantities import nanoAODv15, nanoAODv9
 from .scripts.CROWNWrapper import (defaults,
                                    get_adjusted_add_shift_SystematicShift)
-from .tau_triggersetup import (DOUBLETAU_TRIGGER_FLAG,
-                               DOUBLETAU_TRIGGER_LEG1_FLAGNAME,
-                               DOUBLETAU_TRIGGER_LEG2_FLAGNAME,
-                               DOUBLETAU_TRIGGER_SF_NAME,
-                               ELETAU_CROSS_TRIGGER_FLAG,
-                               MUTAU_CROSS_TRIGGER_FLAG)
+from .tau_triggersetup import RUN2_ERAS, DOUBLETAU_HPS_ERAS
 
 # Map internal era names to JERC JSON era names for JERC sources
 ERA_MAP = {
@@ -642,7 +637,10 @@ def add_Variations(configuration: Configuration, sample: str, era: str) -> Confi
                         "eletau_cross_trigger_leg1_sf": [
                             {
                                 "eletau_cross_trigger_leg1_flagname": "trg_wgt_ele24tau30_leg1",
-                                "eletau_cross_trigger_flag": ELETAU_CROSS_TRIGGER_FLAG,
+                                "eletau_cross_trigger_flag": EraModifier(
+                                    {"2025": "trg_cross_ele24tau30_pnet", "2026": "trg_cross_ele24tau30_pnet"},
+                                    default="trg_cross_ele24tau30_hps",
+                                ),
                                 "eletau_cross_trigger_leg1_sf_name": "Electron-HLT-SF",
                                 "eletau_cross_trigger_leg1_path_id_name": "HLT_SF_Ele24_TightID",
                                 "eletau_cross_trigger_leg1_variation": f"sf{variation}",
@@ -651,7 +649,10 @@ def add_Variations(configuration: Configuration, sample: str, era: str) -> Confi
                         "eletau_cross_trigger_leg2_sf": [
                             {
                                 "eletau_cross_trigger_leg2_flagname": "trg_wgt_ele24tau30_leg2",
-                                "eletau_cross_trigger_flag": ELETAU_CROSS_TRIGGER_FLAG,
+                                "eletau_cross_trigger_flag": EraModifier(
+                                    {"2025": "trg_cross_ele24tau30_pnet", "2026": "trg_cross_ele24tau30_pnet"},
+                                    default="trg_cross_ele24tau30_hps",
+                                ),
                                 "eletau_cross_trigger_leg2_sf_name": "etau",
                                 "eletau_cross_trigger_leg2_variation": variation,
                             },
@@ -711,7 +712,10 @@ def add_Variations(configuration: Configuration, sample: str, era: str) -> Confi
                     ("mt"): {
                         "mutau_trigger_leg1_sf": [
                             {
-                                "mutau_cross_trigger_flag": MUTAU_CROSS_TRIGGER_FLAG,
+                                "mutau_cross_trigger_flag": EraModifier(
+                                    {"2025": "trg_cross_mu20tau27_pnet", "2026": "trg_cross_mu20tau27_pnet"},
+                                    default="trg_cross_mu20tau27_hps",
+                                ),
                                 "mutau_cross_trigger_leg1_flagname": "trg_wgt_mu20tau27_leg1",
                                 "mutau_cross_trigger_leg1_sf_name": "NUM_IsoMu20_DEN_CutBasedIdTight_and_PFIsoTight",
                                 "mutau_cross_trigger_leg1_variation": f"syst{variation}",
@@ -719,7 +723,10 @@ def add_Variations(configuration: Configuration, sample: str, era: str) -> Confi
                         ],
                         "mutau_trigger_leg2_sf": [
                             {
-                                "mutau_cross_trigger_flag": MUTAU_CROSS_TRIGGER_FLAG,
+                                "mutau_cross_trigger_flag": EraModifier(
+                                    {"2025": "trg_cross_mu20tau27_pnet", "2026": "trg_cross_mu20tau27_pnet"},
+                                    default="trg_cross_mu20tau27_hps",
+                                ),
                                 "mutau_cross_trigger_leg2_flagname": "trg_wgt_mu20tau27_leg2",
                                 "mutau_cross_trigger_leg2_sf_name": "mutau",
                                 "mutau_cross_trigger_leg2_variation": variation,
@@ -742,7 +749,10 @@ def add_Variations(configuration: Configuration, sample: str, era: str) -> Confi
                     ("mt"): {
                         "mutau_trigger_leg1_sf": [
                             {
-                                "mutau_cross_trigger_flag": MUTAU_CROSS_TRIGGER_FLAG,
+                                "mutau_cross_trigger_flag": EraModifier(
+                                    {"2025": "trg_cross_mu20tau27_pnet", "2026": "trg_cross_mu20tau27_pnet"},
+                                    default="trg_cross_mu20tau27_hps",
+                                ),
                                 "mutau_cross_trigger_leg1_flagname": "trg_wgt_mu20tau27_leg1",
                                 "mutau_cross_trigger_leg1_sf_name": "NUM_IsoMu20_DEN_CutBasedIdTight_and_PFIsoTight",
                                 "mutau_cross_trigger_leg1_variation": f"stat{variation}",
@@ -765,17 +775,47 @@ def add_Variations(configuration: Configuration, sample: str, era: str) -> Confi
                     ("tt"): {
                         "doubletau_trigger_leg1_sf": [
                             {
-                                "doubletau_trigger_leg1_flagname": DOUBLETAU_TRIGGER_LEG1_FLAGNAME,
-                                "doubletau_trigger_flag": DOUBLETAU_TRIGGER_FLAG,
-                                "doubletau_trigger_leg1_sf_name": DOUBLETAU_TRIGGER_SF_NAME,
+                                "doubletau_trigger_leg1_flagname": EraModifier(
+                                    {
+                                        **{era: '""' for era in RUN2_ERAS},
+                                        **{era: "trg_wgt_doubletau35_leg1" for era in DOUBLETAU_HPS_ERAS},
+                                    },
+                                    default="trg_wgt_doubletau30_leg1",  # 2024, 2025, 2026
+                                ),
+                                "doubletau_trigger_flag": EraModifier(
+                                    {
+                                        **{era: '""' for era in RUN2_ERAS},
+                                        **{era: "trg_double_tau35_mediumiso_hps" for era in DOUBLETAU_HPS_ERAS},
+                                    },
+                                    default="trg_double_tau30_mediumiso_pnet",  # 2024, 2025, 2026
+                                ),
+                                "doubletau_trigger_leg1_sf_name": EraModifier(
+                                    {era: '""' for era in RUN2_ERAS},
+                                    default="ditau",  # all Run 3 eras
+                                ),
                                 "doubletau_trigger_leg1_variation": variation,
                             },
                         ],
                         "doubletau_trigger_leg2_sf": [
                             {
-                                "doubletau_trigger_leg2_flagname": DOUBLETAU_TRIGGER_LEG2_FLAGNAME,
-                                "doubletau_trigger_flag": DOUBLETAU_TRIGGER_FLAG,
-                                "doubletau_trigger_leg2_sf_name": DOUBLETAU_TRIGGER_SF_NAME,
+                                "doubletau_trigger_leg2_flagname": EraModifier(
+                                    {
+                                        **{era: '""' for era in RUN2_ERAS},
+                                        **{era: "trg_wgt_doubletau35_leg2" for era in DOUBLETAU_HPS_ERAS},
+                                    },
+                                    default="trg_wgt_doubletau30_leg2",  # 2024, 2025, 2026
+                                ),
+                                "doubletau_trigger_flag": EraModifier(
+                                    {
+                                        **{era: '""' for era in RUN2_ERAS},
+                                        **{era: "trg_double_tau35_mediumiso_hps" for era in DOUBLETAU_HPS_ERAS},
+                                    },
+                                    default="trg_double_tau30_mediumiso_pnet",  # 2024, 2025, 2026
+                                ),
+                                "doubletau_trigger_leg2_sf_name": EraModifier(
+                                    {era: '""' for era in RUN2_ERAS},
+                                    default="ditau",  # all Run 3 eras
+                                ),
                                 "doubletau_trigger_leg2_variation": variation,
                             },
                         ],


### PR DESCRIPTION
This PR unifies Run 2 and Run 3 handling in config_run3.py behind a single code path, replacing the old pattern of large if blocks with `SwitchProducer` era switches defined per-producer-module, a single unified modification-rule table filtered by an "eras" key instead of being physically split into separate if blocks, and adapts to an upstream CROWN C++ rename of the cut/flag helper API (comparison-operator naming cleanup) from the latest CROWN PRs.

Producer-level changes:

Added SwitchProducer subclasses that pick the right implementation by era/NanoAOD version, e.g.:
- `jets.py`: JetBTagSwitch (run2→DeepFlavour, run3 v12→PNet/v15→UParT), JetIDSwitch, JetRhoSwitch, JetEnergyCorrectionSwitch, GoodJetsSwitch, GoodBJetsSwitch
- `met.py`: MetCorrectionsSwitch, PFMetCorrectionsSwitch, MetBasicsSwitch
- `taus.py`: BaseTausSwitch, GoodTausSwitch, TauEnergyCorrectionSwitch
- `electrons.py`: ElectronPtCorrectionMCSwitch, ElectronPtCorrectionDataSwitch
- `event.py`: DiLeptonVetoSwitch, TopPtReweightingSwitch
- `pairquantities.py`: TTDiTauPairQuantitiesSwitch, MTDiTauPairQuantitiesSwitch, ETDiTauPairQuantitiesSwitch
- `scalefactors.py`: TauID_SFSwitch, btaggingWP_SFSwitch
Renamed all `physicsobject::CutMin/CutMax/CutAbsMax` calls to `CutGreater/CutSmaller/CutAbsSmaller` across `electrons.py`, `muons.py`, `jets.py`, `taus.py`, `photons.py` with minimal modifications to the logic of the analysis itself.

`config_run3.py` changes:

- `MC_ONLY` renamed to `DATA_ONLY`.
- New `TAU_DECAY_MODES = "0,1,10,11"` constant, reused instead of hardcoding the string twice to work over multiple files.
- Added Run2 (non-DM-binned) `tau_id_vsele_barrel`/`_endcap` config params, and Run2 jet selection params (`min_jet_pt=30`, `max_jet_eta=4.7`, no horn treatment), since it was breaking Run 2 production.
- ee/mm scopes now get a tightened lepton-iso cut (0.15 vs. the shared 0.3 baseline) applied after era-specific blocks, since those two scopes have no fake-factor sideband regions and don't need the looser baseline object selection. Cuts come from `smhtt_ul`.
- Era-conditional modification rules are now one flat list filtered by `"eras": RUN2_ERAS`instead of living inside three separate if blocks.
- Added em cross-trigger flags for Run2 eras (`triggers.EMGenerateCrossTriggerFlags`), previously missing.
- Fixed em cross-trigger offline pT thresholds: mu23ele12 leg raised 12→15, mu8ele23 leg raised 8→15, to match the offline em preselection convention from `smhtt_ul` (documented inline).
- Dropped `met.MetMask`/`q.met_mask` output (unused/removed producer) and unified MetBasics output selection through MetBasicsSwitch instead of an if era < 2024 branch.
- Removed the `"fake_era"` special-cased sample from generate.py's sample list and from all the exclude_samples: ["fake_era"] rule filters — the era-based filter replaces what that was working around, since now the `samples`/`exclude_samples` are not necessary anymore.

`tau_triggersetup.py` modifications:

- Removed module-level MUTAU_CROSS_TRIGGER_FLAG/ELETAU_CROSS_TRIGGER_FLAG/DOUBLETAU_TRIGGER_* EraModifier constants; inlined them at point of use instead (each now only needs a 2025/2026 pnet override with an hps default, simpler now that the HPS→PNet transition is the only era split left).
- doubleelectron_trigger config param wrapped in a list ([doubleelectron_trigger_defaults]).

Tested `config_run3.py` to work for both Run2 and Run3 eras now.
